### PR TITLE
Update em_mbta_v05.py

### DIFF
--- a/em_mbta_cohSNR.py
+++ b/em_mbta_cohSNR.py
@@ -108,7 +108,7 @@ def make_MFO_HLV_array(triple_ev,galaxy,TriggerTime):
         if event.parameters.rwSNR > max_SNR : # selects the reference ifo according to the value of re-weightedSNR
             max_SNR=event.parameters.rwSNR
             reference_ifo=event.ifo
-            t_ref=event.parameters.GTime
+            t_ref=event.parameters.StartTime
 
     # computes the time of travel between the reference ifo and the 3 ifos
     galaxy.get_relative_time_delays(reference_ifo,TriggerTime)

--- a/em_mbta_cohSNR.py
+++ b/em_mbta_cohSNR.py
@@ -22,12 +22,13 @@ with open("GCNheader.txt") as GCNheader:
     TriggerTime=
 
 tStart=TriggerTime-0.5 #### per esempio...
+duration=
 
 """ prepares the lists with GW Events for each ifo for the specified
     start-time and  duration""" 
-eventsH=get_gw_events(tStart,duration=1,"H")
-eventsL=get_gw_events(tStart,duration=1,"L")
-eventsV=get_gw_events(tStart,duration=1,"V")
+eventsH=get_gw_events(tStart,duration,"H")
+eventsL=get_gw_events(tStart,duration,"L")
+eventsV=get_gw_events(tStart,duration,"V")
 
 
 """ re-organizes the events to make lists of triple detection for the same template"""
@@ -231,10 +232,10 @@ def compute_cohSNR(triple_ev,galaxy,TriggerTime):
 def get_gw_events(tStart,duration,ifo):
     """ Returns a list of GW events, instancies of the GWEvent class, for given input parameters"""
     events=[]
-    ffl=vt.FrameFile("Mbta%c1_RX_Clstr.ffl"%(ifo))
-    inputFile=ffl.get_frame(TriggerTime) ### dove entra l'informazione dell'ifo??
-    iFile=PyFd.FrFileINew(inputFile) ### come trovare l'input file?
-    event=PyFd.FrEventReadTF(iFile,"Mbta%c_00-Chi2OK"%(ifo), tStart, duration, 0, 0)
+    #ffl=vt.FrameFile("Mbta%c1_RX_Clstr.ffl"%(ifo))
+    inputFile="MbtaHLV-Chi2OK-clustered.gwf" #ffl.get_frame(TriggerTime) 
+    iFile=PyFd.FrFileINew(inputFile) 
+    event=PyFd.FrEventReadTF(iFile,"MbtaHLV-Chi2OK-clustered", tStart, duration, 0, 0)
     while(event):
         ev=em.GWEvent(event,inputFile,ifo)
         ev.get_template_params()

--- a/em_mbta_cohSNR.py
+++ b/em_mbta_cohSNR.py
@@ -215,9 +215,9 @@ def make_MFO_HLV_array(triple_ev,galaxy,TriggerTime):
 def compute_cohSNR(triple_ev,galaxy,TriggerTime):
     """ computes the coherent snr time series and returns 
         the value and the (approximate) gps time of its maximum """
-    MFO_HLV,time_origin = make_MFO_HLV_array(triple_ev,galaxy,TriggerTime)
     M=compute_proj_matrix(triple_ev,galaxy,TriggerTime)
-
+    MFO_HLV,time_origin = make_MFO_HLV_array(triple_ev,galaxy,TriggerTime)
+    
     cohSNR=np.einsum('it,ij,jt->t',MFO_HLV,M,MFO_HLV)  # as Eq.(2.26) in Harry-Fairhurst. t can be viewed as time index
 
     max_cohSNR=max(cohSNR)

--- a/em_mbta_cohSNR.py
+++ b/em_mbta_cohSNR.py
@@ -25,9 +25,9 @@ tStart=TriggerTime-0.5 #### per esempio...
 
 """ prepares the lists with GW Events for each ifo for the specified
     start-time and  duration""" 
-eventsH=get_gw_events(tStart,duration=1,H)
-eventsL=get_gw_events(tStart,duration=1,L)
-eventsV=get_gw_events(tStart,duration=1,V)
+eventsH=get_gw_events(tStart,duration=1,"H")
+eventsL=get_gw_events(tStart,duration=1,"L")
+eventsV=get_gw_events(tStart,duration=1,"V")
 
 
 """ re-organizes the events to make lists of triple detection for the same template"""

--- a/em_mbta_cohSNR.py
+++ b/em_mbta_cohSNR.py
@@ -73,17 +73,17 @@ def compute_proj_matrix(triple_ev,galaxy,TriggerTime):
                 interest galaxy and trigger time (is sufficient as reference time for the scope)"""
     galaxy.get_antenna_patterns(TriggerTime)
     wp=np.array([
-        [np.sqrt(triple_ev[0].parameters.sigma_sq) * galaxy.antenna_patterns_H[0]],
-        [np.sqrt(triple_ev[1].parameters.sigma_sq) * galaxy.antenna_patterns_L[0]],
-        [np.sqrt(triple_ev[2].parameters.sigma_sq) * galaxy.antenna_patterns_V[0]]])
+        np.sqrt(triple_ev[0].parameters.sigma_sq) * galaxy.antenna_patterns_H[0],
+        np.sqrt(triple_ev[1].parameters.sigma_sq) * galaxy.antenna_patterns_L[0],
+        np.sqrt(triple_ev[2].parameters.sigma_sq) * galaxy.antenna_patterns_V[0]])
     wc=np.array([
-        [np.sqrt(triple_ev[0].parameters.sigma_sq) * galaxy.antenna_patterns_H[1]],
-        [np.sqrt(triple_ev[1].parameters.sigma_sq) * galaxy.antenna_patterns_L[1]],
-        [np.sqrt(triple_ev[2].parameters.sigma_sq) * galaxy.antenna_patterns_V[1]]])
+        np.sqrt(triple_ev[0].parameters.sigma_sq) * galaxy.antenna_patterns_H[1],
+        np.sqrt(triple_ev[1].parameters.sigma_sq) * galaxy.antenna_patterns_L[1],
+        np.sqrt(triple_ev[2].parameters.sigma_sq) * galaxy.antenna_patterns_V[1]])
     
     a=np.dot(wp,wp)
     b=np.dot(wc,wc)
-    c=np.dot(wp.wc)
+    c=np.dot(wp,wc)
     det=a*b-c**2
     zeros=np.zeros((2,2))
     block=np.array([[b, -c],
@@ -117,20 +117,20 @@ def make_MFO_HLV_array(triple_ev,galaxy,TriggerTime):
     min_delay=min(galaxy.time_delays[galaxy.time_delays!=0])
 
     Hrw_timeseries=np.array([
-        [galaxy.antenna_patterns_H[0]*triple_ev[0].mfo_data[:,0]],  # Fplus_H  h_phase
-        [galaxy.antenna_patterns_H[1]*triple_ev[0].mfo_data[:,0]],  # Fcross_H h_phase
-        [galaxy.antenna_patterns_H[0]*triple_ev[0].mfo_data[:,1]],  # Fplus_H  h_quadr
-        [galaxy.antenna_patterns_H[1]*triple_ev[0].mfo_data[:,1]]]) # Fcross_H h_quadr 
+        galaxy.antenna_patterns_H[0]*triple_ev[0].mfo_data[:,0],  # Fplus_H  h_phase
+        galaxy.antenna_patterns_H[1]*triple_ev[0].mfo_data[:,0],  # Fcross_H h_phase
+        galaxy.antenna_patterns_H[0]*triple_ev[0].mfo_data[:,1],  # Fplus_H  h_quadr
+        galaxy.antenna_patterns_H[1]*triple_ev[0].mfo_data[:,1]]) # Fcross_H h_quadr 
     Lrw_timeseries=np.array([
-        [galaxy.antenna_patterns_L[0]*triple_ev[1].mfo_data[:,0]],
-        [galaxy.antenna_patterns_L[1]*triple_ev[1].mfo_data[:,0]],
-        [galaxy.antenna_patterns_L[0]*triple_ev[1].mfo_data[:,1]],
-        [galaxy.antenna_patterns_L[1]*triple_ev[1].mfo_data[:,1]]])
+        galaxy.antenna_patterns_L[0]*triple_ev[1].mfo_data[:,0],
+        galaxy.antenna_patterns_L[1]*triple_ev[1].mfo_data[:,0],
+        galaxy.antenna_patterns_L[0]*triple_ev[1].mfo_data[:,1],
+        galaxy.antenna_patterns_L[1]*triple_ev[1].mfo_data[:,1]])
     Vrw_timeseries=np.array([
-        [galaxy.antenna_patterns_V[0]*triple_ev[2].mfo_data[:,0]],
-        [galaxy.antenna_patterns_V[1]*triple_ev[2].mfo_data[:,0]],
-        [galaxy.antenna_patterns_V[0]*triple_ev[2].mfo_data[:,1]],
-        [galaxy.antenna_patterns_V[1]*triple_ev[2].mfo_data[:,1]]])
+        galaxy.antenna_patterns_V[0]*triple_ev[2].mfo_data[:,0],
+        galaxy.antenna_patterns_V[1]*triple_ev[2].mfo_data[:,0],
+        galaxy.antenna_patterns_V[0]*triple_ev[2].mfo_data[:,1],
+        galaxy.antenna_patterns_V[1]*triple_ev[2].mfo_data[:,1]])
 
     #### appends zeros to time series according to the time delay 
     #### in order to prepare them to be summed together     

--- a/em_mbta_cohSNR.py
+++ b/em_mbta_cohSNR.py
@@ -238,9 +238,9 @@ def get_gw_events(tStart,duration,ifo):
     event=PyFd.FrEventReadTF(iFile,"MbtaHLV-Chi2OK-clustered", tStart, duration, 0, 0)
     while(event):
         ev=em.GWEvent(event,inputFile,ifo)
+        ev.get_mfo()
         ev.get_template_params()
         if ev.parameters.mass1 <= 3 and ev.parameters.mass2 <= 3 : # selects only BNS candidates
-            ev.get_mfo()
             events.append(ev)
             event=event[0].next
         else:

--- a/em_mbta_v05.py
+++ b/em_mbta_v05.py
@@ -32,7 +32,7 @@ class Galaxy(object):
             sky location; i.e. return t1-t2 where t1 is the arrival time at the "current detector"
             (H for dtH, V for dtV etc) and t2 is the arrival time in the reference ifo.
         """
-        ref_ifo=pycbc.detector('{ifo}1'.format(ifo=reference_ifo))
+        ref_ifo=pycbc.detector.Detector('{ifo}1'.format(ifo=reference_ifo))
 
         def dtH(ra,dec):
             return H1.time_delay_from_other_detector(other_detector=ref_ifo, 

--- a/em_mbta_v05.py
+++ b/em_mbta_v05.py
@@ -76,7 +76,7 @@ class Galaxy(object):
 
 class GWEvent(object):
 
-    Params=collections.namedtuple('Parameters',['tmplt_index','mass1','mass2',
+    Params=collections.namedtuple('Parameters',['GTime','tmplt_index','mass1','mass2',
                                     'MChirp','spin1z','spin2z','rwSNR','sigma_sq'])    
                                     #GTime is the vector time origin GPS time [s]
 
@@ -115,7 +115,7 @@ class GWEvent(object):
             mass1, mass2, MChirp, spin1z, spin2z,re-weighted SNR and 
             the sensibility of the detector (sigma_sq).
         """
-        self.parameters=self.Params(self.event[0].parameters[0],
+        self.parameters=self.Params(self.vect[0].GTime,self.event[0].parameters[0],
                                 self.event[0].parameters[2],self.event[0].parameters[3],
                                 self.event[0].parameters[4],self.event[0].parameters[5],
                                 self.event[0].parameters[6],self.event[0].parameters[19],

--- a/em_mbta_v05.py
+++ b/em_mbta_v05.py
@@ -35,13 +35,13 @@ class Galaxy(object):
         ref_ifo=pycbc.detector.Detector('{ifo}1'.format(ifo=reference_ifo))
 
         def dtH(ra,dec):
-            return H1.time_delay_from_other_detector(other_detector=ref_ifo, 
+            return H1.time_delay_from_detector(other_detector=ref_ifo, 
                                 right_ascension=ra,declination=dec, t_gps=gps_time)
         def dtL(ra,dec):
-            return L1.time_delay_from_other_detector(other_detector=ref_ifo, right_ascension=ra,
+            return L1.time_delay_from_detector(other_detector=ref_ifo, right_ascension=ra,
                                                     declination=dec, t_gps=gps_time)
         def dtV(ra,dec):
-            return V1.time_delay_from_other_detector(other_detector=ref_ifo, right_ascension=ra,
+            return V1.time_delay_from_detector(other_detector=ref_ifo, right_ascension=ra,
                                                     declination=dec, t_gps=gps_time)
             
         self.time_delays=np.array([dtH(self.ra,self.dec),dtL(self.ra,self.dec),

--- a/em_mbta_v05.py
+++ b/em_mbta_v05.py
@@ -94,8 +94,8 @@ class GWEvent(object):
             Output: 2D numpy array with the matched filtering output in phase and quadrature
         """
         PyFd.FrEventReadData(self.i_file,self.event);
-        self.vect=PyFd.FrEventGetVectF(self.event,"{ifo}1:MF output - phase".format(ifo=self.ifo))
-        Quad_vect=PyFd.FrEventGetVectF(self.event,"{ifo}1:MF output - quadrature".format(ifo=self.ifo))
+        self.vect=PyFd.FrEventGetVectF(self.event,"{ifo}1:MFO_measured_P".format(ifo=self.ifo))
+        Quad_vect=PyFd.FrEventGetVectF(self.event,"{ifo}1:MFO_measured_Q".format(ifo=self.ifo))
         Phase_vect=self.vect
 
         A=Phase_vect[0].nData

--- a/em_mbta_v05.py
+++ b/em_mbta_v05.py
@@ -76,7 +76,7 @@ class Galaxy(object):
 
 class GWEvent(object):
 
-    Params=collections.namedtuple('Parameters',['GTime','tmplt_index','mass1','mass2',
+    Params=collections.namedtuple('Parameters',['tmplt_index','mass1','mass2',
                                     'MChirp','spin1z','spin2z','rwSNR','sigma_sq'])    
                                     #GTime is the vector time origin GPS time [s]
 
@@ -111,11 +111,11 @@ class GWEvent(object):
 
     def get_template_params(self):
         """ Output: named tuple containing the values of the following parameters
-            for the template of the event in consideration: GTime, template index, 
+            for the template of the event in consideration: template index, 
             mass1, mass2, MChirp, spin1z, spin2z,re-weighted SNR and 
             the sensibility of the detector (sigma_sq).
         """
-        self.parameters=self.Params(self.vect[0].GTime,self.event[0].parameters[0],
+        self.parameters=self.Params(self.event[0].parameters[0],
                                 self.event[0].parameters[2],self.event[0].parameters[3],
                                 self.event[0].parameters[4],self.event[0].parameters[5],
                                 self.event[0].parameters[6],self.event[0].parameters[19],

--- a/em_mbta_v05.py
+++ b/em_mbta_v05.py
@@ -76,9 +76,9 @@ class Galaxy(object):
 
 class GWEvent(object):
 
-    Params=collections.namedtuple('Parameters',['GTime','tmplt_index','mass1','mass2',
+    Params=collections.namedtuple('Parameters',['StartTime','tmplt_index','mass1','mass2',
                                     'MChirp','spin1z','spin2z','rwSNR','sigma_sq'])    
-                                    #GTime is the vector time origin GPS time [s]
+                                    #StartTime is the vector time origin GPS time [s]
 
     def __init__(self,event,inputFile,ifo):
         self.event=event
@@ -111,11 +111,11 @@ class GWEvent(object):
 
     def get_template_params(self):
         """ Output: named tuple containing the values of the following parameters
-            for the template of the event in consideration: template index, 
+            for the template of the event in consideration: absolute GPS start time of the vector, template index, 
             mass1, mass2, MChirp, spin1z, spin2z,re-weighted SNR and 
             the sensibility of the detector (sigma_sq).
         """
-        self.parameters=self.Params(self.vect[0].GTime,self.event[0].parameters[0],
+        self.parameters=self.Params(self.vect[0].startX[0],self.event[0].parameters[0],
                                 self.event[0].parameters[2],self.event[0].parameters[3],
                                 self.event[0].parameters[4],self.event[0].parameters[5],
                                 self.event[0].parameters[6],self.event[0].parameters[19],

--- a/em_mbta_v05.py
+++ b/em_mbta_v05.py
@@ -65,7 +65,7 @@ class Galaxy(object):
 
         def VFpc(ra,dec):
             Fplus,Fcross=V1.antenna_pattern(right_ascension=ra, declination=dec, polarization=0,
-                                            tgps=gps_time)
+                                            t_gps=gps_time)
             return np.array([Fplus,Fcross])
 
 


### PR DESCRIPTION
GTime removed from parameters so to allow check the masses before extracting the MFO. Is it GTime a necessary parameter? Could we use the end-time instead?